### PR TITLE
Fix getMetaDir failure in windows due to path.join

### DIFF
--- a/src/commands/build-util.ts
+++ b/src/commands/build-util.ts
@@ -106,12 +106,13 @@ export async function buildFile(
 }
 
 export function getMetaDir(config: SnowpackConfig) {
-  let {baseUrl, metaDir} = config?.buildOptions || {};
-  metaDir = metaDir?.replace(/^\/?((.*[^/])\/?$)?/, '$2');
+  let {baseUrl, metaDir} = config.buildOptions || {};
+  metaDir = metaDir.replace(/^\/?((.*[^/])\/?$)?/, '$2');
   if (URL_HAS_PROTOCOL_REGEX.test(baseUrl)) {
     return metaDir;
   }
-  return path.join(baseUrl, metaDir).replace(/^\//, '');
+  baseUrl = baseUrl.replace(/^\/?((.*[^/])\/?$)?/, '$2');
+  return baseUrl ? baseUrl + '/' + metaDir : metaDir;
 }
 
 export function wrapImportMeta({


### PR DESCRIPTION
## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
